### PR TITLE
Add uuid, timestamp and binary to processor

### DIFF
--- a/lib/processor.js
+++ b/lib/processor.js
@@ -43,9 +43,13 @@ module.exports = function(callbacks) {
                 return cbMap.fixed('null', null);
             case 'boolean':
                 return cbMap.fixed('boolean', encodedVal[1]);
+            case 'uuid':
+            case 'timestamp':
+                return cbMap.fixed(type, encodedVal[1]);
 
             case 'string':
             case 'symbol':
+            case 'binary':
                 return cbMap.variable(type, encodedVal[1]);
 
             case 'list':


### PR DESCRIPTION
Adds three types to the processor so that implementations can choose whether or not to support them:
- uuid
- timestamp
- binary
