### PR TITLE
Add support for UUID type and tests for fixed width types

### DIFF
--- a/lib/encoded_to_buffer_builder.js
+++ b/lib/encoded_to_buffer_builder.js
@@ -1,5 +1,6 @@
 var builder = require('buffer-builder'),
-    processor = require('./processor');
+    processor = require('./processor'),
+    u = require('./utilities');
 
 function encodeToBuilder(encoded, bufb) {
     if (bufb === undefined) bufb = new builder();
@@ -92,6 +93,10 @@ function encodeToBuilder(encoded, bufb) {
                     break;
                 case 'boolean':
                     bufb.appendUInt8(val ? 0x41 : 0x42);
+                    break;
+                case 'uuid':
+                    bufb.appendUInt8(0x98);
+                    bufb.appendBuffer(new Buffer(u.parseUuid(val)));
                     break;
                 default:
                     throw new Error('Unknown fixed: ' + type);

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -42,7 +42,8 @@ module.exports = function(callbacks) {
             case 'null':
                 return cbMap.fixed('null', null);
             case 'boolean':
-                return cbMap.fixed('boolean', encodedVal[1]);
+            case 'uuid':
+                return cbMap.fixed(type, encodedVal[1]);
 
             case 'string':
             case 'symbol':

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -1,0 +1,28 @@
+// Maps for number <-> hex string conversion
+var BYTE_TO_HEX = [];
+var HEX_TO_BYTE = {};
+for (var i = 0; i < 256; i++) {
+  BYTE_TO_HEX[i] = (i + 0x100).toString(16).substr(1);
+  HEX_TO_BYTE[BYTE_TO_HEX[i]] = i;
+}
+
+function parseUuid(s, buf, offset) {
+  var i = (buf && offset) || 0, ii = 0;
+  buf = buf || [];
+  s.toLowerCase().replace(/[0-9a-f]{2}/g, function(oct) {
+    if (ii < 16) { // Don't overflow!
+      buf[i + ii++] = HEX_TO_BYTE[oct];
+    }
+  });
+
+  // Zero out remaining bytes if string was short
+  while (ii < 16) {
+    buf[i + ii++] = 0;
+  }
+
+  return buf;
+}
+
+module.exports = {
+  parseUuid: parseUuid
+};

--- a/test/test_encoded_to_buffer_builder.js
+++ b/test/test_encoded_to_buffer_builder.js
@@ -27,6 +27,26 @@ describe('toBufferBuilder', function() {
         })
     });
 
+    describe('#fixed()', function() {
+        it('should encode true', function() {
+            var input = ['boolean', true];
+            var expected = tu.newBuf([0x41]);
+            tu.shouldBufEql(expected, toBuilder(input));
+        });
+
+        it('should encode false', function() {
+            var input = ['boolean', false];
+            var expected = tu.newBuf([0x42]);
+            tu.shouldBufEql(expected, toBuilder(input));
+        });
+
+        it('should encode a UUID', function() {
+            var input = ['uuid', "f667a20f-a7d1-4ac9-9939-6f90c06d61d3"];
+            var expected = tu.newBuf([0x98, 0xF6, 0x67, 0xA2, 0x0F, 0xA7, 0xD1, 0x4A, 0xC9, 0x99, 0x39, 0x6F, 0x90, 0xC0, 0x6D, 0x61, 0xD3]);
+            tu.shouldBufEql(expected, toBuilder(input));
+        });
+    });
+
     describe('#described()', function() {
         it('should allow simple descriptors, values', function() {
             var str = 'open frame contents';


### PR DESCRIPTION
Also bringing in some utillity functions from amqp10 - your call to decide if that needs a separate repo, or fits into a "common" one, or if you simply don't want it (it's needed only for the buffer builder which I don't need, the only changes I really need are in `processor.js`)